### PR TITLE
Fix `release_origins` for Debian Jessie and potentially newer versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ docs/Makefile
 docs/_build/
 docs/conf.py
 docs/defaults.rst
+docs/includes/global.rst
+docs/_templates/page.html
+docs/_templates/.gitkeep
+docs/_static/custom.css
+docs/_static/.gitkeep

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ install: True
 script:
   - 'git clone --depth 1 https://github.com/nickjj/rolespec'
   - 'cd rolespec ; bin/rolespec -r https://github.com/debops/test-suite'
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,17 @@ The current role maintainer is drybjed.
 
 .. _debops.unattended_upgrades master: https://github.com/debops/ansible-unattended_upgrades/compare/v0.2.0...master
 
+Added
+~~~~~
+
 - Support nested lists for :envvar:`unattended_upgrades__blacklist` and
   :envvar:`unattended_upgrades__origins`. [ypid]
+
+Fixed
+~~~~~
+
+- Fixed :envvar:`unattended_upgrades__release_origins` for Debian Jessie and
+  potentially newer versions. [ypid_]
 
 `debops.unattended_upgrades v0.2.0`_ - 2016-07-09
 -------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,14 @@
 Changelog
 =========
 
+.. include:: includes/all.rst
+
 **debops.unattended_upgrades**
 
-This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_
+This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__
 and `human-readable changelog <http://keepachangelog.com/>`_.
 
-The current role maintainer is drybjed.
+The current role maintainer_ is drybjed_.
 
 `debops.unattended_upgrades master`_ - unreleased
 -------------------------------------------------
@@ -17,7 +19,7 @@ Added
 ~~~~~
 
 - Support nested lists for :envvar:`unattended_upgrades__blacklist` and
-  :envvar:`unattended_upgrades__origins`. [ypid]
+  :envvar:`unattended_upgrades__origins`. [ypid_]
 
 Fixed
 ~~~~~
@@ -36,19 +38,19 @@ Added
 - ``state`` option for :envvar:`unattended_upgrades__blacklist` and similar
   lists when using the dictionary notation. This replaces the removed
   ``when`` option. The ``state`` allows to remove entries from the blacklist
-  which ``when`` did not. [ypid]
+  which ``when`` did not. [ypid_]
 
 - Support dictionary notation for :envvar:`unattended_upgrades__origins` and
-  :envvar:`unattended_upgrades__dependent_origins` lists. [ypid]
+  :envvar:`unattended_upgrades__dependent_origins` lists. [ypid_]
 
 - Documentation for :envvar:`unattended_upgrades__origins`.
 
-- Add ``vim`` fold markers in ``defaults/main.yml`` file. [drybjed]
+- Add ``vim`` fold markers in :file:`defaults/main.yml` file. [drybjed_]
 
 Changed
 ~~~~~~~
 
-- Reworked role to meet the latest DebOps standards. [ypid]
+- Reworked role to meet the latest DebOps standards. [ypid_]
 
 Fixed
 ~~~~~
@@ -57,17 +59,17 @@ Fixed
   to be a regular expression and a mix between glob and regular expression.
   The previous given example also works for some reason so this fix is merely
   to follow the upstream documentation more strictly.
-  [ypid]
+  [ypid_]
 
 Removed
 ~~~~~~~
 
 - ``when`` option from :envvar:`unattended_upgrades__blacklist` and similar
   lists when using the dictionary notation. It has been superseded by the
-  ``state`` option to allow to remove entries from the blacklist. [ypid]
+  ``state`` option to allow to remove entries from the blacklist. [ypid_]
 
 - Remove the automatic blacklisting of the ``vim`` and ``libc6`` packages.
-  Nothing is blacklisted by default. [ypid]
+  Nothing is blacklisted by default. [ypid_]
 
 
 `debops.unattended_upgrades v0.1.4`_ - 2016-03-02
@@ -78,7 +80,7 @@ Removed
 Fixed
 ~~~~~
 
-- Fix issue with role import on Ansible Galaxy. [drybjed]
+- Fix issue with role import on Ansible Galaxy. [drybjed_]
 
 `debops.unattended_upgrades v0.1.3`_ - 2016-03-02
 -------------------------------------------------
@@ -88,7 +90,7 @@ Fixed
 Added
 ~~~~~
 
-- Add support for conditional package blacklisting. [drybjed]
+- Add support for conditional package blacklisting. [drybjed_]
 
 `debops.unattended_upgrades v0.1.2`_ - 2016-02-22
 -------------------------------------------------
@@ -104,7 +106,7 @@ Changed
   on Debian Wheezy which stops the upgrades from being performed,
   ``debops.unattended_upgrades`` role will now use more granular lookup strings
   to select security and release origin patterns for current OS release.
-  [drybjed]
+  [drybjed_]
 
 `debops.unattended_upgrades v0.1.1`_ - 2016-02-10
 -------------------------------------------------
@@ -114,7 +116,7 @@ Changed
 Removed
 ~~~~~~~
 
-- Rename all variables to create a virtual namespace. [drybjed]
+- Rename all variables to create a virtual namespace. [drybjed_]
 
 debops.unattended_upgrades v0.1.0 - 2016-02-09
 ----------------------------------------------
@@ -122,4 +124,4 @@ debops.unattended_upgrades v0.1.0 - 2016-02-09
 Added
 ~~~~~
 
-- Initial release. [drybjed]
+- Initial release. [drybjed_]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,12 +21,12 @@ unattended_upgrades__enabled: True
                                                                    # ]]]
 # .. envvar:: unattended_upgrades__release [[[
 #
-# By default, :program:`unattended-upgrade` performs only upgrades of packages from
-# security repositories. This variable allows you to enable upgrades from all
-# repositories (main, updates, backports).
+# By default, :program:`unattended-upgrade` performs only upgrades of packages
+# from security repositories. This variable allows you to enable upgrades from
+# all repositories (main, updates, backports).
 #
-# If a host does not have a domain set, it will be considered as a workstation
-# or a laptop and :program:`unattended-upgrade` will perform upgrades of packages
+# If a host does not have a domain set, it will be considered a workstation or
+# a laptop and :program:`unattended-upgrade` will perform upgrades of packages
 # from all repositories.
 unattended_upgrades__release: '{{ False if ansible_domain else True }}'
 
@@ -125,7 +125,7 @@ unattended_upgrades__security_origins:
 # OS release. Enabled/disabled by the :envvar:`unattended_upgrades__release` variable.
 unattended_upgrades__release_origins:
 
-  'Debian_wheezy':
+  'Debian':
     - 'o=Debian'
     - 'o=Debian Backports'
 
@@ -254,5 +254,6 @@ unattended_upgrades__auto_reboot_time: '02:30'
 #
 # Limit the amount of bandwidth used by APT to download packages, in kb/s.
 unattended_upgrades__bandwidth_limit: ''
+                                                                   # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,9 +125,14 @@ unattended_upgrades__security_origins:
 # OS release. Enabled/disabled by the :envvar:`unattended_upgrades__release` variable.
 unattended_upgrades__release_origins:
 
-  'Debian':
+  'Debian_wheezy':
     - 'o=Debian'
     - 'o=Debian Backports'
+
+  'Debian':
+    - 'o={distro_id},n=${distro_codename}'
+    - 'o={distro_id},n=${distro_codename}-updates'
+    - 'o=${distro_id} Backports,n=${distro_codename}-backports'
 
   'default':
     - 'o=${distro_id},n=${distro_codename}'

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -103,14 +103,14 @@ The available values on the system are printed by the command
 "unattended-upgrades -d" and looking at the log file.
 
 Within lines unattended-upgrades allows 2 macros whose values are
-derived from ``/etc/debian_version``::
+derived from :file:`/etc/debian_version`::
 
   ${distro_id}            Installed origin.
   ${distro_codename}      Installed codename (eg, "jessie")
 
 Codename based matching:
 This will follow the migration of a release through different
-archives (e.g. from testing to stable and later oldstable)::
+archives (e. g. from testing to stable and later oldstable)::
 
      "o=Debian,n=jessie";
      "o=Debian,n=jessie-updates";
@@ -119,7 +119,7 @@ archives (e.g. from testing to stable and later oldstable)::
 
 Archive or Suite based matching:
 Note that this will silently match a different release after
-migration to the specified archive (e.g. testing becomes the
+migration to the specified archive (e. g. testing becomes the
 new stable)::
 
      "o=Debian,a=stable";

--- a/docs/includes/all.rst
+++ b/docs/includes/all.rst
@@ -1,0 +1,1 @@
+.. include:: includes/global.rst


### PR DESCRIPTION
According to `apt-cache policy | grep release`:

```
release a=now
release o=obs://s2.owncloud.com/ce:9.0/Debian_8.0,n=Debian_8.0,l=ce:9.0,c=
release o=Debian Backports,a=jessie-backports,n=jessie-backports,l=Debian Backports,c=non-free
release o=Debian Backports,a=jessie-backports,n=jessie-backports,l=Debian Backports,c=contrib
release o=Debian Backports,a=jessie-backports,n=jessie-backports,l=Debian Backports,c=main
release o=Debian,a=stable-updates,n=jessie-updates,l=Debian,c=non-free
release o=Debian,a=stable-updates,n=jessie-updates,l=Debian,c=contrib
release o=Debian,a=stable-updates,n=jessie-updates,l=Debian,c=main
release v=8.5,o=Debian,a=stable,n=jessie,l=Debian,c=non-free
release v=8.5,o=Debian,a=stable,n=jessie,l=Debian,c=contrib
release v=8.5,o=Debian,a=stable,n=jessie,l=Debian,c=main
release v=8,o=Debian,a=stable,n=jessie,l=Debian-Security,c=non-free
release v=8,o=Debian,a=stable,n=jessie,l=Debian-Security,c=contrib
release v=8,o=Debian,a=stable,n=jessie,l=Debian-Security,c=main
```

the default values should still work with Jessie but they somehow don’t. I probably missed something why the fallback default does not work with Jessie.

Confirmed working for: Debian Jessie
Depends on: https://github.com/debops/docs/pull/196

@drybjed: Have you tested this on Jessie yet?