### PR TITLE
Add Sender (mail_from) for custom email address for sending status mails

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -224,6 +224,12 @@ unattended_upgrades__minimal_steps: True
 # performing it in the background.
 unattended_upgrades__install_on_shutdown: False
 
+# ]]]
+# .. envvar:: unattended_upgrades__mail_from [[[
+#
+# The eMail address written to FROM field
+# If empty, use the /usr/bin/unattended-upgrade default
+unattended_upgrades__mail_from: ''
                                                                    # ]]]
 # .. envvar:: unattended_upgrades__mail_to [[[
 #

--- a/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
+++ b/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
@@ -64,6 +64,12 @@ Unattended-Upgrade::MinimalSteps "{{ unattended_upgrades__minimal_steps | bool |
 // This will (obviously) make shutdown slower
 Unattended-Upgrade::InstallOnShutdown "{{ unattended_upgrades__install_on_shutdown | bool | lower }}";
 
+
+{% if unattended_upgrades__mail_from %}
+// Send email FROM this address
+Unattended-Upgrade::Sender "{{ unattended_upgrades__mail_from }}";
+{% endif %}
+
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
 // have a working mail setup on your system. A package that provides


### PR DESCRIPTION
Very small addition to config file i found during digging into the emailing functions of unattended upgrades python script.