### PR TITLE
Untangle duplicate parameter declaration

### DIFF
--- a/templates/etc/apt/apt.conf.d/20auto-upgrades.j2
+++ b/templates/etc/apt/apt.conf.d/20auto-upgrades.j2
@@ -1,2 +1,3 @@
-APT::Periodic::Update-Package-Lists "{{ '1' if unattended_upgrades__enabled|bool else '0' }}";
+// Do "apt-get update" automatically every n-days (0=disable)
+APT::Periodic::Update-Package-Lists "{{ '1' if unattended_upgrades__periodic|bool else '0' }}";
 APT::Periodic::Unattended-Upgrade "{{ '1' if unattended_upgrades__enabled|bool else '0' }}";

--- a/templates/etc/apt/apt.conf.d/20periodic.j2
+++ b/templates/etc/apt/apt.conf.d/20periodic.j2
@@ -3,9 +3,6 @@
 // Enable the update/upgrade script (0=disable)
 APT::Periodic::Enable "{{ '1' if unattended_upgrades__periodic|bool else '0' }}";
 
-// Do "apt-get update" automatically every n-days (0=disable)
-APT::Periodic::Update-Package-Lists "{{ '1' if unattended_upgrades__periodic|bool else '0' }}";
-
 // Do "apt-get upgrade --download-only" every n-days (0=disable)
 APT::Periodic::Download-Upgradeable-Packages "{{ "1" if unattended_upgrades__periodic_download|bool else '0' }}";
 


### PR DESCRIPTION
`APT::Periodic::Update-Package-Lists` is defined in two templates:
- `20periodic`
- `20auto-upgrades`

The two locations reference different default vars to determine the state of the parameter, which seems like a potential source of major headaches and confusion.
I removed one instance of the parameter declaration, and attempted to pick the right file and var, based on comments in `defaults/main.yml` and the current local wind vector. If this is not a correct solution, please feel free to close this PR and decide for yourself if this should be solved, and if so how.